### PR TITLE
TKO-67: update the docker compose file to include the local db container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
+FROM csunmetalab/environment:base-20190130 as base
+COPY . /var/www/html
+RUN apt-get update && apt-get install -y \
+      git \
+      vim
 # Backend
 FROM composer:latest as vendor
 COPY database/ database/
 COPY composer.json composer.json
 COPY composer.lock composer.lock
-
 RUN composer install \
     --ignore-platform-reqs \
     --no-interaction \
@@ -26,10 +30,6 @@ COPY --from=vendor /app/vendor/ /var/www/html/vendor/
 COPY --from=frontend /app/public/js/ /var/www/html/public/js/
 COPY --from=frontend /app/public/css/ /var/www/html/public/css/
 COPY --from=frontend /app/mix-manifest.json /var/www/html/mix-manifest.json
-RUN apt-get update && apt-get install -y \
-      git \
-      vim \
-      yarn
 # Change /var/www permission
 RUN chown -hR www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
 # Expose port 80 and 443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,25 @@
 version: '3.3'
 services:
-  badges:
-    container_name: badges
+  takeoff:
+    container_name: takeoff
     build:
       context: .
     ports:
       - 8080:80
     volumes:
       - .:/var/www/html
+  db:
+    image: mysql:5.6.41
+    container_name: takeoff_db
+    restart: always
+    environment:
+      MYSQL_DATABASE: takeoff
+      MYSQL_USER: takeoff
+      MYSQL_PASSWORD: takeoff
+      MYSQL_ROOT_PASSWORD: takeoff
+    ports:
+      - 3306:3306
+    volumes:
+      - db_data:/var/lib/mysql/
+volumes:
+    db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
-version: '3.3'
+version: '3.7'
 services:
   takeoff:
     container_name: takeoff
     build:
       context: .
+      target: base
     ports:
       - 8080:80
     volumes:


### PR DESCRIPTION
# Description
'To avoid sharing the same remote DB across developers, this docker container establishes a local mySQL for dev and testing '
  
# Testing
'Tester should be able to run docker-compose up -d and see the container running. Tester should also be able to connect to the DB via a DB manager/viewer'

# Installation
'.env credentials must match the docker-compose db credentials'
