### PR TITLE
HOTFIX-4-12-2019--addForceHTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+FORCE_HTTPS=false
+
 LOG_CHANNEL=stack
 
 DB_CONNECTION=mysql

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,7 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
-	\CSUNMetaLab\ForceHttps\Http\Middleware\ForceHttps::class,
+        \CSUNMetaLab\ForceHttps\Http\Middleware\ForceHttps::class,
 
     ];
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,8 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+	\CSUNMetaLab\ForceHttps\Http\Middleware\ForceHttps::class,
+
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
+        "csun-metalab/laravel-force-https": "^1.0",
         "csun-metalab/laravel-proxypass": "^1.1",
         "fideloper/proxy": "^4.0",
         "guzzlehttp/guzzle": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,47 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8d0e5d0104f21be8a7835f6c274a602",
+    "content-hash": "5e633fd4621143d259df057162a627a6",
     "packages": [
+        {
+            "name": "csun-metalab/laravel-force-https",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/csun-metalab/laravel-force-https.git",
+                "reference": "87d1e4505d27733ce9b2956d27cf33714cc0c9d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/csun-metalab/laravel-force-https/zipball/87d1e4505d27733ce9b2956d27cf33714cc0c9d8",
+                "reference": "87d1e4505d27733ce9b2956d27cf33714cc0c9d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/ForceHttps/"
+                ],
+                "psr-4": {
+                    "CSUNMetaLab\\ForceHttps\\": "src/ForceHttps/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Fritz",
+                    "email": "mattf@burbankparanormal.com"
+                }
+            ],
+            "description": "A small Composer package for Laravel 5.0 and above to force HTTPS in the URL",
+            "time": "2018-01-30T19:32:22+00:00"
+        },
         {
             "name": "csun-metalab/laravel-proxypass",
             "version": "1.1.0",

--- a/config/app.php
+++ b/config/app.php
@@ -185,6 +185,7 @@ return [
         App\Providers\ModelRepositoryServiceProvider::class,
 	     /** META+LAB Proxy Pass. */
         CSUNMetaLab\ProxyPass\Providers\ProxyPassServiceProvider::class,
+        CSUNMetaLab\ForceHttps\Providers\ForceHttpsServiceProvider::class,
     ],
 
     /*

--- a/config/forcehttps.php
+++ b/config/forcehttps.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+	/*
+    |--------------------------------------------------------------------------
+    | Force HTTPS
+    |--------------------------------------------------------------------------
+    |
+    | Whether to force HTTPS on all URLs or not. Default is false.
+    |
+    */
+	'force_https' => env('FORCE_HTTPS', false),
+
+];


### PR DESCRIPTION
# Description
Installed force https package
1. I created a HOTFIX branch
2. I did composer require csun-metalab/laravel-force-https 
3. Followed remainder of steps found here https://github.com/csun-metalab/laravel-force-https
 
# Testing
1. Go on browser and visit `https://localhost:8080`
2. Add new env value sent to email
3. If you see
<img width="336" alt="Screen Shot 2019-04-17 at 11 46 56 AM" src="https://user-images.githubusercontent.com/36258268/56313081-8e809400-6106-11e9-9f10-8e26a8cc52b1.png"> 
it worked (remove https to go back to main page)

4. This error will be resolved on our dev/demo/deployed environments as we have necessary ssl certs to provide secure connection.

# Installation
N/A

`composer install`